### PR TITLE
Fixes Issue #6 (Unhandled exceptions no longer being reported to the inspector dashboard)

### DIFF
--- a/src/Config/Events.php
+++ b/src/Config/Events.php
@@ -34,3 +34,9 @@ if (config('Inspector')->AutoInspect) {
         Services::inspector()->getSegment()->end();
     });
 }
+
+if (config('Inspector')->LogUnhandledExceptions) {
+    Events::on('pre_system', static function () {
+        Services::inspector()->initialize();
+    });
+}

--- a/tests/InspectorTest.php
+++ b/tests/InspectorTest.php
@@ -2,6 +2,7 @@
 
 namespace Inspector\CodeIgniter\Tests;
 
+use CodeIgniter\Events\Events;
 use Config\Services;
 use Inspector\CodeIgniter\Inspector;
 use Inspector\CodeIgniter\Tests\Support\TestCase;
@@ -14,12 +15,12 @@ final class InspectorTest extends TestCase
 {
     protected function simulateEventStart(): void
     {
-        \CodeIgniter\Events\Events::trigger('post_controller_constructor');
+        Events::trigger('post_controller_constructor');
     }
 
     protected function simulateEventEnd(): void
     {
-        \CodeIgniter\Events\Events::trigger('post_system');
+        Events::trigger('post_system');
     }
 
     public function testAutoInspectStartsTransaction()


### PR DESCRIPTION
Fix issue with the latest CodeIgniter 4 release, where unhandled exceptions are no longer being reported to the inspector dashboard/backend.

This solution has been tested rigorously over the past week and we are confident to share it with the rest of the users of the library.

This fixed #6 